### PR TITLE
Point to GOV.UK for local council hubs

### DIFF
--- a/app/views/signposting.html
+++ b/app/views/signposting.html
@@ -103,7 +103,7 @@
                 <span class="search-tags">food, medication, self-isolating, council, community hubs</span>
               </td>
               <td class="govuk-table__cell">Food, medication and other support coordinated by local councils. Search by postcode.</td>
-              <td class="govuk-table__cell"><a href="https://www.theyhelpyou.co.uk/" target="_blank">Website</a>
+              <td class="govuk-table__cell"><a href="https://www.gov.uk/coronavirus-local-help" target="_blank">Website</a>
               </td>
               <td class="govuk-table__cell">UK wide</td>
             </tr>


### PR DESCRIPTION
TheyHelpYou data has now been donated to GOV.UK, who are now maintaining it alongside MHCLG and the LGA. TheyHelpYou is now mostly used to signpost to GOV.UK, and will eventually be retired.